### PR TITLE
会員ログイン新規登録後の遷移先、住所自動追加機能アップデート

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,13 +6,13 @@ class ApplicationController < ActionController::Base
 
   #会員新規登録時のパス
   def after_sign_up_path_for(resource)
-    mypage_customers_path
+    root_path
   end
 
   #ログイン時のパス
   def after_sign_in_path_for(resource)
     if customer_signed_in?
-      mypage_customers_path
+      root_path
     else
       admin_root_path
     end

--- a/app/controllers/customer/orders_controller.rb
+++ b/app/controllers/customer/orders_controller.rb
@@ -46,6 +46,7 @@ class Customer::OrdersController < ApplicationController
       @order.postal_code  = params[:order][:postal_code]
       @order.address      = params[:order][:address]
       @order.address_name = params[:order][:address_name]
+      @shipping = "auto_add_address"
     end
   end
 
@@ -53,6 +54,16 @@ class Customer::OrdersController < ApplicationController
     @order = current_customer.orders.new(order_params)
     @order.save
     redirect_to thanks_orders_path
+
+    #新しい住所を選択した場合に配送先住所として保存
+    if @shipping = "auto_add_address"
+      Address.create(
+        customer_id: current_customer.id,
+        postal_code: params[:order][:postal_code],
+        address: params[:order][:address],
+        name: params[:order][:address_name]
+      )
+    end
 
     #カート内商品を注文詳細に受け渡して、カートを空にする
     @cart_items = current_customer.cart_items


### PR DESCRIPTION
会員ログインまたは新規登録後の遷移先をトップページに修正しました。
新しい住所を選択して注文が確定された際に、該当する住所が会員の配送先住所として登録されるようにしました。