### PR TITLE
配送先追加と注文情報入力の際の住所検索

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,7 +18,7 @@
 //= require jquery.jposta
 //= require_tree .
 
-// 住所検索機能
+// 新規登録住所検索機能
 $(function(){
   $(document).on('turbolinks:load', () => {
     $('#customer_postal_code').jpostal({
@@ -27,6 +27,34 @@ $(function(){
       ],
       address: {
         "#customer_address": "%3%4%5%6%7"
+      }
+    });
+  });
+});
+
+// 配送先住所検索機能
+$(function(){
+  $(document).on('turbolinks:load', () => {
+    $('#address_postal_code').jpostal({
+      postcode: [
+        '#address_postal_code'
+      ],
+      address: {
+        "#address_address": "%3%4%5%6%7"
+      }
+    });
+  });
+});
+
+// 注文情報入力住所検索機能
+$(function(){
+  $(document).on('turbolinks:load', () => {
+    $('#order_new_postal_code').jpostal({
+      postcode: [
+        '#order_new_postal_code'
+      ],
+      address: {
+        "#order_new_address": "%3%4%5%6%7"
       }
     });
   });

--- a/app/views/customer/orders/new.html.erb
+++ b/app/views/customer/orders/new.html.erb
@@ -46,13 +46,13 @@
 				<div class="form-group row">
 					<%= f.label :"郵便番号(ハイフンなし)", class: "col-form-label col-xs-4" %>
 					<div class="col-xs-3">
-						<%= f.text_field :postal_code, class: "form-control input-sm" %>
+						<%= f.text_field :postal_code, class: "form-control input-sm", id: "order_new_postal_code" %>
 					</div>
 				</div>
 				<div class="form-group row">
 					<%= f.label :"住所", class: "col-form-label col-xs-4" %>
 					<div class="col-xs-8">
-						<%= f.text_field :address, class: "form-control input-sm" %>
+						<%= f.text_field :address, class: "form-control input-sm", id: "order_new_address" %>
 					</div>
 				</div>
 				<div class="form-group row">


### PR DESCRIPTION
会員新規登録でのみ住所検索できる状態でしたが、配送先追加時と注文情報入力時に新しい住所を選択した時でも住所検索できるようにしました！